### PR TITLE
fix: 포트 분리

### DIFF
--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -11,4 +11,5 @@ springdoc:
     swagger-ui:
         path: /swagger-ui.html
 
-
+server:
+  port: 10001

--- a/api/src/test/kotlin/com/inner/circle/api/TestApiPaymentApplication.kt
+++ b/api/src/test/kotlin/com/inner/circle/api/TestApiPaymentApplication.kt
@@ -8,7 +8,6 @@ object TestApiPaymentApplication {
     fun main(args: Array<String>) {
         runApplication<ApiApplication>(*args) {
             addInitializers(PostgreSqlTestContainerConfiguration())
-            setDefaultProperties(mapOf("server.port" to "8088"))
         }
     }
 }


### PR DESCRIPTION
## 개요
* AWS - EC2 - application-server에 앱이 같이 떠야 한다면, 포트를 미리 분리해 두면 좋을 것 같습니다!

혹시 분리가 필요 없다면 알려주세요~ 
AWS 쪽 낯설어서 작업 좀 해보려구요!

> 티켓 번호 : #port-fix

## PR 유형
- [X] 기타 (설명을 남겨주세요.) -> {}
