### PR TITLE
feat(infra-reddis_config_with_profiles): redis 설정을 profile 별로 가변 처리

### DIFF
--- a/api/src/main/kotlin/com/inner/circle/api/config/SwaggerConfig.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/config/SwaggerConfig.kt
@@ -4,24 +4,31 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.servers.Server
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 
 @Profile("local | dev")
 @Configuration
-class SwaggerConfig {
+class SwaggerConfig(
+    @Value("\${swagger.server-url}") private val serverUrl: String
+) {
     val securitySchemeName = "basicAuth"
 
     @Bean
-    fun customOpenAPI(): OpenAPI =
-        OpenAPI()
+    fun customOpenAPI(): OpenAPI {
+        val server = Server().url(serverUrl) // 환경별 서버 URL 설정
+
+        return OpenAPI()
             .info(
                 Info()
                     .title("Pay200 API Docs")
                     .version("1.0")
                     .description("PG 결제 프로젝트")
-            ).addSecurityItem(SecurityRequirement().addList(securitySchemeName))
+            ).addServersItem(server)
+            .addSecurityItem(SecurityRequirement().addList(securitySchemeName))
             .components(
                 io.swagger.v3.oas.models
                     .Components()
@@ -33,4 +40,5 @@ class SwaggerConfig {
                             .scheme("basic")
                     )
             )
+    }
 }

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -31,6 +31,9 @@ card:
     approve-end-point: /mock/card/approve
     validate-end-point: /mock/card/validate
 
+swagger:
+  server-url: http://localhost:10001
+
 ---
 spring:
   config:
@@ -43,3 +46,6 @@ card:
     base-url: http://localhost:8082
     approve-end-point: /mock/card/approve
     validate-end-point: /mock/card/validate
+
+swagger:
+  server-url: https://payment.pay-200.com

--- a/infra/src/main/kotlin/com/inner/circle/infra/config/RedisConfig.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/config/RedisConfig.kt
@@ -26,7 +26,7 @@ class RedisConfig {
             LettuceClientConfiguration
                 .builder()
 
-        if (!environment.activeProfiles.any { it in listOf("local", "test") }) {
+        if (!environment.matchesProfiles("local", "test")) {
             lettuceClientConfigurationBuilder.useSsl().disablePeerVerification()
         }
 
@@ -38,8 +38,8 @@ class RedisConfig {
     }
 
     @Bean
-    fun redisTemplate(environment: Environment): StringRedisTemplate {
-        val template = StringRedisTemplate(redisConnectionFactory(environment))
+    fun redisTemplate(redisConnectionFactory: RedisConnectionFactory): StringRedisTemplate {
+        val template = StringRedisTemplate(redisConnectionFactory)
         template.keySerializer = StringRedisSerializer()
         template.valueSerializer = GenericJackson2JsonRedisSerializer()
         return template


### PR DESCRIPTION
- swagger 설정 변경
- local, test 에서는 tls 설정이 불가능하여 profile에 따른 tls (ssl) 설정 가변 처리

## 개요
<!-- pr 에 대한 간략한 설명을 작성해 주세요. -->

> 티켓 번호 : # {}

## PR 유형
<!-- 해당 pr 의 유형을 선택해 주세요. -->
- [ ] 문서 수정
- [ ] 기타 (설명을 남겨주세요.) -> redis tls 설정은 elasticCache에서만 적용되어야 하므로 설정을 가변 처리했습니다.
