### PR TITLE
feat(sse event message send): 결제 요청 시 payment-ready event message 전달

### DIFF
--- a/api/src/main/kotlin/com/inner/circle/api/application/PaymentStatusChangedMessageSender.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/application/PaymentStatusChangedMessageSender.kt
@@ -1,0 +1,46 @@
+package com.inner.circle.api.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.inner.circle.api.application.dto.PaymentStatusChangedResponse
+import com.inner.circle.api.application.dto.PaymentStatusChangedSsePaymentRequest
+import com.inner.circle.core.sse.SseConnectionPool
+import com.inner.circle.exception.SseException
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class PaymentStatusChangedMessageSender(
+    private val sseConnectionPool: SseConnectionPool,
+    private val objectMapper: ObjectMapper
+) {
+    companion object {
+        private val log = LoggerFactory.getLogger(PaymentStatusChangedMessageSender::class.java)
+    }
+
+    fun sendProcessChangedMessage(ssePaymentRequest: PaymentStatusChangedSsePaymentRequest) {
+        val merchantId = ssePaymentRequest.merchantId
+        val orderId = ssePaymentRequest.orderId
+        val eventType = ssePaymentRequest.eventType
+
+        try {
+            val uniqueKey = merchantId + "_" + orderId
+            val session =
+                sseConnectionPool.getSession(
+                    uniqueKey
+                )
+            val eventData = PaymentStatusChangedResponse.of(eventType, orderId, uniqueKey)
+            val eventMessage = objectMapper.writeValueAsString(eventData)
+
+            session.sendMessage(eventType, eventMessage)
+            log.info(
+                "sse message send. (merchantId: {}, orderId: {}, eventType: {})",
+                merchantId,
+                orderId,
+                eventType
+            )
+        } catch (e: NoSuchElementException) {
+            log.error("get sse session failed", e)
+            throw SseException.connectionNotFound(merchantId, orderId)
+        }
+    }
+}

--- a/api/src/main/kotlin/com/inner/circle/api/application/dto/PaymentStatusChangedResponse.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/application/dto/PaymentStatusChangedResponse.kt
@@ -1,0 +1,19 @@
+package com.inner.circle.api.application.dto
+
+data class PaymentStatusChangedResponse(
+    val status: String,
+    val orderId: String,
+    val merchantId: String
+) {
+    companion object {
+        fun of(
+            status: String,
+            orderId: String,
+            merchantId: String
+        ) = PaymentStatusChangedResponse(
+            status = status,
+            orderId = orderId,
+            merchantId = merchantId
+        )
+    }
+}

--- a/api/src/main/kotlin/com/inner/circle/api/application/dto/PaymentStatusChangedSsePaymentRequest.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/application/dto/PaymentStatusChangedSsePaymentRequest.kt
@@ -1,0 +1,8 @@
+package com.inner.circle.api.application.dto
+
+data class PaymentStatusChangedSsePaymentRequest(
+    val eventType: String,
+    val status: String,
+    val orderId: String,
+    val merchantId: String
+)

--- a/api/src/main/kotlin/com/inner/circle/api/application/dto/PaymentStatusEventType.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/application/dto/PaymentStatusEventType.kt
@@ -1,0 +1,45 @@
+package com.inner.circle.api.application.dto
+
+enum class PaymentStatusEventType(
+    private val eventFlag: String
+) {
+    /**
+     * 결제를 생성하면 가지게 되는 초기 상태입니다.
+     * 인증 전까지는 READY 상태를 유지합니다.
+     */
+    READY("payment-ready"),
+
+    /**
+     * 결제수단 정보로 결제수단 인증을 요청할 수 있는 상태입니다.
+     */
+    IN_VERIFICATE("payment-in-verificate"),
+
+    /**
+     * 결제수단 정보와 해당 결제수단의 소유자가 맞는지 인증을 마친 상태입니다.
+     * 결제 승인 API를 호출하면 결제가 완료됩니다.
+     */
+    IN_PROGRESS("payment-in-progress"),
+
+    /**
+     * 인증된 결제수단으로 요청한 결제가 승인된 상태입니다.
+     */
+    DONE("payment-done"),
+
+    /**
+     * 요청한 결제가 취소된 상태입니다.
+     */
+    CANCELED("payment-canceled"),
+
+    /**
+     * 결제 승인에 실패한 상태입니다.
+     */
+    ABORTED("payment-aborted"),
+
+    /**
+     * 요청된 결제의 유효 시간 N분이 지나 거래가 취소된 상태입니다.
+     * IN_PROGRESS 상태에서 결제 승인 API를 호출하지 않으면 EXPIRED가 됩니다.
+     */
+    EXPIRED("payment-expired");
+
+    fun getEventType(): String = eventFlag
+}

--- a/api/src/main/kotlin/com/inner/circle/api/security/SecurityConfig.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/security/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package com.inner.circle.api.security
 
+import jakarta.servlet.DispatcherType
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.Customizer.withDefaults
@@ -14,20 +15,22 @@ class SecurityConfig {
     @Bean
     fun apiSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
-            .csrf { it.disable() }
             .authorizeHttpRequests { authorizeRequests ->
                 authorizeRequests
+                    .dispatcherTypeMatchers(DispatcherType.ERROR, DispatcherType.ASYNC) // 오류 페이지, 비동기 요청 허용
+                    .permitAll()
                     .requestMatchers(
                         "/api-docs/**",
                         "/swagger-ui/**",
                         "/health-check",
                         "/api/payment/v1/sse/**"
-                    ).permitAll()
+                    ).permitAll() // swagger, sse 연결은 permit
                     .requestMatchers("/api/payment/v1/payments", "/api/payment/v1/payments/**")
                     .authenticated()
             }.sessionManagement { session ->
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            }.csrf { it.disable() }
+            }.httpBasic { it.disable() }
+            .csrf { it.disable() }
             .httpBasic(withDefaults())
 
         return http.build()

--- a/api/src/main/kotlin/com/inner/circle/api/security/SecurityConfig.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/security/SecurityConfig.kt
@@ -17,7 +17,8 @@ class SecurityConfig {
         http
             .authorizeHttpRequests { authorizeRequests ->
                 authorizeRequests
-                    .dispatcherTypeMatchers(DispatcherType.ERROR, DispatcherType.ASYNC) // 오류 페이지, 비동기 요청 허용
+                    // 오류 페이지, 비동기 요청 허용
+                    .dispatcherTypeMatchers(DispatcherType.ERROR, DispatcherType.ASYNC)
                     .permitAll()
                     .requestMatchers(
                         "/api-docs/**",

--- a/core/src/main/kotlin/com/inner/circle/core/service/JwtHandler.kt
+++ b/core/src/main/kotlin/com/inner/circle/core/service/JwtHandler.kt
@@ -26,7 +26,7 @@ class JwtHandler {
         val expirationDate = Date(issuedAt.time + 1000 * 60 * expiresMinute)
         return Jwts
             .builder()
-            .subject(paymentClaimDto.orderId)
+            .claim("orderId", paymentClaimDto.orderId)
             .claim("merchantId", paymentClaimDto.merchantId)
             .claim("orderName", paymentClaimDto.orderName)
             .claim("amount", paymentClaimDto.amount)

--- a/exception/src/main/kotlin/com/inner/circle/exception/SseException.kt
+++ b/exception/src/main/kotlin/com/inner/circle/exception/SseException.kt
@@ -1,0 +1,18 @@
+package com.inner.circle.exception
+
+class SseException(
+    status: HttpStatus,
+    override val message: String,
+    override val cause: Throwable? = null
+) : AppException(status, message, cause) {
+    companion object {
+        fun connectionNotFound(
+            merchantId: String,
+            orderId: String
+        ): SseException =
+            SseException(
+                HttpStatus.NOT_FOUND,
+                "SSE connection not found for merchantId: $merchantId, orderId: $orderId"
+            )
+    }
+}


### PR DESCRIPTION
## 개요
- SSE message 전송을 위해 api 패키지에서 전송 로직 추가

> 티켓 번호 : #82

## PR 유형
<!-- 해당 pr 의 유형을 선택해 주세요. -->
- [ ] 새로운 기능 추가
- [ ] 기타 (설명을 남겨주세요.) -> PaymentStatusChangedMessageSender.kt 로 별도 Service를 빼고, api에서 처리하려 하는데, 이 부분을 core로 내려가야 할지 고민입니다.
