### PR TITLE
상태변경을 통해 멱등성을 보장 개발

### DIFF
--- a/core/src/main/kotlin/com/inner/circle/core/service/ConfirmPaymentService.kt
+++ b/core/src/main/kotlin/com/inner/circle/core/service/ConfirmPaymentService.kt
@@ -6,6 +6,7 @@ import com.inner.circle.core.sse.SseConnectionPool
 import com.inner.circle.core.usecase.ConfirmPaymentUseCase
 import com.inner.circle.core.usecase.ConfirmSimplePaymentUseCase
 import com.inner.circle.exception.AuthenticateException
+import com.inner.circle.exception.PaymentException
 import com.inner.circle.infra.adaptor.dto.PaymentProcessStatus
 import com.inner.circle.infra.http.HttpClient
 import com.inner.circle.infra.port.ConfirmPaymentPort
@@ -44,6 +45,12 @@ internal class ConfirmPaymentService(
             throw AuthenticateException.CardAuthFailException()
         }
 
+        if (request.orderStatus != PaymentProcessStatus.READY) {
+            throw PaymentException.InvalidOrderStatusException(
+                request.orderStatus.toString()
+            )
+        }
+
         val paymentKeyTsid = TSID.fast().toString()
 
         val result =
@@ -60,7 +67,7 @@ internal class ConfirmPaymentService(
             SavePaymentRequestPort.Request(
                 orderId = request.orderId,
                 orderName = request.orderName,
-                orderStatus = PaymentProcessStatus.valueOf(request.orderStatus.name),
+                orderStatus = PaymentProcessStatus.IN_PROGRESS,
                 accountId = request.accountId,
                 merchantId = request.merchantId,
                 merchantName = request.merchantName,

--- a/core/src/main/kotlin/com/inner/circle/core/service/SavePaymentApproveService.kt
+++ b/core/src/main/kotlin/com/inner/circle/core/service/SavePaymentApproveService.kt
@@ -76,7 +76,7 @@ internal class SavePaymentApproveService(
                     paymentPort
                         .save(
                             PaymentPort.Request(
-                                id = paymentRequest.id,
+                                id = null,
                                 paymentKey =
                                     paymentRequest.paymentKey
                                         ?: throw PaymentException.PaymentKeyNotFoundException(),
@@ -93,7 +93,7 @@ internal class SavePaymentApproveService(
                         ).let {
                             transactionPort.save(
                                 TransactionPort.Request(
-                                    id = paymentRequest.id,
+                                    id = null,
                                     paymentKey =
                                         paymentRequest.paymentKey
                                             ?: throw PaymentException.PaymentKeyNotFoundException(),

--- a/core/src/main/kotlin/com/inner/circle/core/service/SavePaymentApproveService.kt
+++ b/core/src/main/kotlin/com/inner/circle/core/service/SavePaymentApproveService.kt
@@ -3,7 +3,6 @@ package com.inner.circle.core.service
 import com.inner.circle.core.domain.Currency
 import com.inner.circle.core.domain.PaymentType
 import com.inner.circle.core.service.dto.PaymentApproveDto
-import com.inner.circle.core.service.dto.PaymentDto
 import com.inner.circle.core.service.dto.PaymentRequestDto
 import com.inner.circle.core.usecase.SavePaymentApproveUseCase
 import com.inner.circle.exception.CardCompanyException
@@ -95,8 +94,9 @@ internal class SavePaymentApproveService(
                             transactionPort.save(
                                 TransactionPort.Request(
                                     id = paymentRequest.id,
-                                    paymentKey = paymentRequest.paymentKey
-                                        ?: throw PaymentException.PaymentKeyNotFoundException(),
+                                    paymentKey =
+                                        paymentRequest.paymentKey
+                                            ?: throw PaymentException.PaymentKeyNotFoundException(),
                                     amount = paymentRequestDto.amount,
                                     status = TransactionStatus.APPROVED,
                                     reason = null,
@@ -112,8 +112,9 @@ internal class SavePaymentApproveService(
                                     accountId = paymentRequest.accountId,
                                     merchantId = paymentRequest.merchantId,
                                     merchantName = paymentRequest.merchantName,
-                                    paymentKey = paymentRequest.paymentKey
-                                        ?: throw PaymentException.PaymentKeyNotFoundException(),
+                                    paymentKey =
+                                        paymentRequest.paymentKey
+                                            ?: throw PaymentException.PaymentKeyNotFoundException(),
                                     amount = paymentRequest.amount,
                                     cardNumber = paymentRequest.cardNumber ?: "",
                                     paymentType = paymentRequest.paymentType,

--- a/core/src/main/kotlin/com/inner/circle/core/service/dto/PaymentInfoDto.kt
+++ b/core/src/main/kotlin/com/inner/circle/core/service/dto/PaymentInfoDto.kt
@@ -1,14 +1,14 @@
 package com.inner.circle.core.service.dto
 
 import com.inner.circle.core.domain.PaymentInfo
-import com.inner.circle.infra.repository.entity.PaymentStatusType
+import com.inner.circle.infra.adaptor.dto.PaymentProcessStatus
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
 data class PaymentInfoDto(
     val orderId: String,
     val orderName: String?,
-    val orderStatus: PaymentStatusType,
+    val orderStatus: PaymentProcessStatus,
     val accountId: Long?,
     val merchantId: String,
     val paymentKey: String?,
@@ -24,7 +24,7 @@ data class PaymentInfoDto(
             PaymentInfoDto(
                 orderId = paymentInfo.orderId,
                 orderName = paymentInfo.orderName,
-                orderStatus = PaymentStatusType.valueOf(paymentInfo.orderStatus.name),
+                orderStatus = PaymentProcessStatus.valueOf(paymentInfo.orderStatus.name),
                 accountId = paymentInfo.accountId,
                 merchantId = paymentInfo.merchantId,
                 merchantName = paymentInfo.merchantName,

--- a/exception/src/main/kotlin/com/inner/circle/exception/PaymentException.kt
+++ b/exception/src/main/kotlin/com/inner/circle/exception/PaymentException.kt
@@ -50,4 +50,10 @@ sealed class PaymentException(
         override val message: String = "Payment method (card) not found.",
         override val cause: Throwable? = null
     ) : PaymentException(HttpStatus.BAD_REQUEST, message, cause)
+
+    data class InvalidOrderStatusException(
+        val orderStatus: String,
+        override val message: String = "$orderStatus is not in IN_PROGRESS state.",
+        override val cause: Throwable? = null
+    ) : PaymentException(HttpStatus.BAD_REQUEST, message, cause)
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/adaptor/ConfirmPaymentAdaptor.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/adaptor/ConfirmPaymentAdaptor.kt
@@ -2,6 +2,7 @@ package com.inner.circle.infra.adaptor
 
 import com.inner.circle.exception.PaymentException
 import com.inner.circle.infra.adaptor.dto.ConfirmPaymentInfraDto
+import com.inner.circle.infra.adaptor.dto.PaymentProcessStatus
 import com.inner.circle.infra.port.ConfirmPaymentPort
 import com.inner.circle.infra.repository.PaymentRequestRepository
 import com.inner.circle.infra.repository.UserCardRepository
@@ -24,7 +25,7 @@ internal class ConfirmPaymentAdaptor(
         return ConfirmPaymentInfraDto(
             orderId = paymentRequest.orderId,
             orderName = paymentRequest.orderName,
-            orderStatus = paymentRequest.orderStatus,
+            orderStatus = PaymentProcessStatus.valueOf(paymentRequest.orderStatus.name),
             accountId = paymentRequest.accountId,
             merchantId = paymentRequest.merchantId,
             merchantName = paymentRequest.merchantName,

--- a/infra/src/main/kotlin/com/inner/circle/infra/adaptor/PaymentAdaptor.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/adaptor/PaymentAdaptor.kt
@@ -12,7 +12,7 @@ internal class PaymentAdaptor(
     private val paymentRepository: PaymentRepository
 ) : PaymentPort {
     @Transactional
-    override fun save(request: PaymentPort.Request){
+    override fun save(request: PaymentPort.Request) {
         paymentRepository.save(
             PaymentEntity(
                 id = request.id,

--- a/infra/src/main/kotlin/com/inner/circle/infra/adaptor/PaymentAdaptor.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/adaptor/PaymentAdaptor.kt
@@ -11,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional
 internal class PaymentAdaptor(
     private val paymentRepository: PaymentRepository
 ) : PaymentPort {
-    @Transactional
     override fun save(request: PaymentPort.Request) {
         paymentRepository.save(
             PaymentEntity(

--- a/infra/src/main/kotlin/com/inner/circle/infra/adaptor/PaymentAdaptor.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/adaptor/PaymentAdaptor.kt
@@ -5,12 +5,14 @@ import com.inner.circle.infra.port.PaymentPort
 import com.inner.circle.infra.repository.PaymentRepository
 import com.inner.circle.infra.repository.entity.PaymentEntity
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 internal class PaymentAdaptor(
     private val paymentRepository: PaymentRepository
 ) : PaymentPort {
-    override fun save(request: PaymentPort.Request): PaymentEntity =
+    @Transactional
+    override fun save(request: PaymentPort.Request){
         paymentRepository.save(
             PaymentEntity(
                 id = request.id,
@@ -26,4 +28,5 @@ internal class PaymentAdaptor(
         ) ?: throw PaymentException.PaymentNotSaveException(
             paymentKey = request.paymentKey
         )
+    }
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/adaptor/PaymentAdaptor.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/adaptor/PaymentAdaptor.kt
@@ -5,7 +5,6 @@ import com.inner.circle.infra.port.PaymentPort
 import com.inner.circle.infra.repository.PaymentRepository
 import com.inner.circle.infra.repository.entity.PaymentEntity
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
 
 @Component
 internal class PaymentAdaptor(

--- a/infra/src/main/kotlin/com/inner/circle/infra/adaptor/TransactionAdaptor.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/adaptor/TransactionAdaptor.kt
@@ -11,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional
 internal class TransactionAdaptor(
     private val transactionRepository: TransactionRepository
 ) : TransactionPort {
-    @Transactional
     override fun save(request: TransactionPort.Request) {
         transactionRepository.save(
             TransactionEntity(

--- a/infra/src/main/kotlin/com/inner/circle/infra/adaptor/TransactionAdaptor.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/adaptor/TransactionAdaptor.kt
@@ -5,7 +5,6 @@ import com.inner.circle.infra.repository.TransactionRepository
 import com.inner.circle.infra.repository.entity.TransactionEntity
 import java.time.LocalDateTime
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
 
 @Component
 internal class TransactionAdaptor(

--- a/infra/src/main/kotlin/com/inner/circle/infra/adaptor/TransactionAdaptor.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/adaptor/TransactionAdaptor.kt
@@ -1,18 +1,18 @@
 package com.inner.circle.infra.adaptor
 
 import com.inner.circle.infra.port.TransactionPort
-import com.inner.circle.infra.repository.PaymentRepository
 import com.inner.circle.infra.repository.TransactionRepository
 import com.inner.circle.infra.repository.entity.TransactionEntity
 import java.time.LocalDateTime
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 internal class TransactionAdaptor(
-    private val transactionRepository: TransactionRepository,
-    private val paymentRepository: PaymentRepository
+    private val transactionRepository: TransactionRepository
 ) : TransactionPort {
-    override fun save(request: TransactionPort.Request): TransactionEntity =
+    @Transactional
+    override fun save(request: TransactionPort.Request){
         transactionRepository.save(
             TransactionEntity(
                 id = request.id,
@@ -26,4 +26,5 @@ internal class TransactionAdaptor(
         ) ?: throw IllegalArgumentException(
             "Payment Transaction not save"
         )
+    }
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/adaptor/TransactionAdaptor.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/adaptor/TransactionAdaptor.kt
@@ -12,7 +12,7 @@ internal class TransactionAdaptor(
     private val transactionRepository: TransactionRepository
 ) : TransactionPort {
     @Transactional
-    override fun save(request: TransactionPort.Request){
+    override fun save(request: TransactionPort.Request) {
         transactionRepository.save(
             TransactionEntity(
                 id = request.id,

--- a/infra/src/main/kotlin/com/inner/circle/infra/adaptor/dto/ConfirmPaymentInfraDto.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/adaptor/dto/ConfirmPaymentInfraDto.kt
@@ -1,13 +1,12 @@
 package com.inner.circle.infra.adaptor.dto
 
-import com.inner.circle.infra.repository.entity.PaymentStatusType
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
 data class ConfirmPaymentInfraDto(
     val orderId: String,
     val orderName: String?,
-    val orderStatus: PaymentStatusType,
+    val orderStatus: PaymentProcessStatus,
     val accountId: Long?,
     val merchantId: String,
     val paymentKey: String?,

--- a/infra/src/main/kotlin/com/inner/circle/infra/port/PaymentPort.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/port/PaymentPort.kt
@@ -1,7 +1,6 @@
 package com.inner.circle.infra.port
 
 import com.inner.circle.infra.repository.entity.Currency
-import com.inner.circle.infra.repository.entity.PaymentEntity
 import com.inner.circle.infra.repository.entity.PaymentType
 
 fun interface PaymentPort {
@@ -17,5 +16,5 @@ fun interface PaymentPort {
         val cardNumber: String
     )
 
-    fun save(request: Request): PaymentEntity
+    fun save(request: Request)
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/port/TransactionPort.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/port/TransactionPort.kt
@@ -1,6 +1,5 @@
 package com.inner.circle.infra.port
 
-import com.inner.circle.infra.repository.entity.TransactionEntity
 import com.inner.circle.infra.repository.entity.TransactionStatus
 import java.math.BigDecimal
 import java.time.LocalDateTime

--- a/infra/src/main/kotlin/com/inner/circle/infra/port/TransactionPort.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/port/TransactionPort.kt
@@ -3,6 +3,7 @@ package com.inner.circle.infra.port
 import com.inner.circle.infra.repository.entity.TransactionEntity
 import com.inner.circle.infra.repository.entity.TransactionStatus
 import java.math.BigDecimal
+import java.time.LocalDateTime
 
 fun interface TransactionPort {
     data class Request(
@@ -10,8 +11,9 @@ fun interface TransactionPort {
         val paymentKey: String,
         val amount: BigDecimal,
         val status: TransactionStatus,
-        val reason: String?
+        val reason: String?,
+        val requestedAt: LocalDateTime
     )
 
-    fun save(request: Request): TransactionEntity
+    fun save(request: Request)
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/repository/PaymentJpaRepository.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/repository/PaymentJpaRepository.kt
@@ -3,5 +3,4 @@ package com.inner.circle.infra.repository
 import com.inner.circle.infra.repository.entity.PaymentEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface PaymentJpaRepository : JpaRepository<PaymentEntity, String> {
-}
+interface PaymentJpaRepository : JpaRepository<PaymentEntity, String>

--- a/infra/src/main/kotlin/com/inner/circle/infra/repository/PaymentJpaRepository.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/repository/PaymentJpaRepository.kt
@@ -4,7 +4,4 @@ import com.inner.circle.infra.repository.entity.PaymentEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface PaymentJpaRepository : JpaRepository<PaymentEntity, String> {
-    fun save(paymentEntity: PaymentEntity): PaymentEntity?
-
-    fun findByPaymentKey(paymentKey: String): PaymentEntity?
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/repository/PaymentRepository.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/repository/PaymentRepository.kt
@@ -4,6 +4,4 @@ import com.inner.circle.infra.repository.entity.PaymentEntity
 
 interface PaymentRepository {
     fun save(paymentEntity: PaymentEntity): PaymentEntity?
-
-    fun findByPaymentKey(paymentKey: String): PaymentEntity?
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/repository/PaymentRepositoryImpl.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/repository/PaymentRepositoryImpl.kt
@@ -8,8 +8,5 @@ internal class PaymentRepositoryImpl(
     private val paymentJpaRepository: PaymentJpaRepository
 ) : PaymentRepository {
     override fun save(paymentEntity: PaymentEntity): PaymentEntity? =
-        paymentJpaRepository.save(paymentEntity)
-
-    override fun findByPaymentKey(paymentKey: String): PaymentEntity? =
-        paymentJpaRepository.findByPaymentKey(paymentKey)
+        paymentJpaRepository.saveAndFlush(paymentEntity)
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/repository/TransactionJpaRepository.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/repository/TransactionJpaRepository.kt
@@ -4,5 +4,4 @@ import com.inner.circle.infra.repository.entity.TransactionEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface TransactionJpaRepository : JpaRepository<TransactionEntity, String> {
-    fun save(transactionEntity: TransactionEntity): TransactionEntity?
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/repository/TransactionJpaRepository.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/repository/TransactionJpaRepository.kt
@@ -3,5 +3,4 @@ package com.inner.circle.infra.repository
 import com.inner.circle.infra.repository.entity.TransactionEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface TransactionJpaRepository : JpaRepository<TransactionEntity, String> {
-}
+interface TransactionJpaRepository : JpaRepository<TransactionEntity, String>

--- a/infra/src/main/kotlin/com/inner/circle/infra/repository/TransactionRepositoryImpl.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/repository/TransactionRepositoryImpl.kt
@@ -4,7 +4,7 @@ import com.inner.circle.infra.repository.entity.TransactionEntity
 import org.springframework.stereotype.Repository
 
 @Repository
-internal class TransacrionRepositoryImpl(
+internal class TransactionRepositoryImpl(
     private val transactionJpaRepository: TransactionJpaRepository
 ) : TransactionRepository {
     override fun save(transactionEntity: TransactionEntity): TransactionEntity? =

--- a/infra/src/main/kotlin/com/inner/circle/infra/repository/entity/PaymentRequestEntity.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/repository/entity/PaymentRequestEntity.kt
@@ -28,6 +28,7 @@ data class PaymentRequestEntity(
     @Column(name = "card_number")
     val cardNumber: String?,
     @Column(name = "payment_type")
+    @Enumerated(EnumType.STRING)
     val paymentType: PaymentType = PaymentType.CARD,
     @Column(name = "merchant_id", nullable = false)
     val merchantId: String,
@@ -39,5 +40,6 @@ data class PaymentRequestEntity(
     val paymentToken: String?,
     @Column(name = "request_time", nullable = false)
     val requestTime: LocalDateTime,
+    @Column(name = "merchant_name")
     val merchantName: String
 ) : BaseEntity()


### PR DESCRIPTION
## 개요
상태변경을 통해 멱등성을 보장하기 위해 카드 인증 승인에 상태변경 로직 추가했습니다.
그런데 카드 승인에서 payment 테이블에 insert하는 로직에서 아래 에러가 발생합니다.
Caused by: org.hibernate.StaleObjectStateException: Row was updated or deleted by another transaction

도움 요청드립니다. ㅠㅠ

> 티켓 번호 : # {}

## PR 유형
<!-- 해당 pr 의 유형을 선택해 주세요. -->
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 추가
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (설명을 남겨주세요.) -> {}
