### PR TITLE
hotfix: #190 Spring Security Exception Handling 이슈 수정

### DIFF
--- a/api/src/main/kotlin/com/inner/circle/api/exception/CustomAuthenticationEntryPoint.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/exception/CustomAuthenticationEntryPoint.kt
@@ -1,0 +1,4 @@
+package com.inner.circle.api.exception
+
+class CustomAuthenticationEntryPoint {
+}

--- a/api/src/main/kotlin/com/inner/circle/api/exception/CustomAuthenticationEntryPoint.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/exception/CustomAuthenticationEntryPoint.kt
@@ -1,4 +1,36 @@
 package com.inner.circle.api.exception
 
-class CustomAuthenticationEntryPoint {
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.inner.circle.api.controller.dto.PaymentError
+import com.inner.circle.api.controller.dto.PaymentResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+
+@Component
+class CustomAuthenticationEntryPoint : AuthenticationEntryPoint {
+    private val mapper = ObjectMapper()
+
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        val error =
+            PaymentResponse.fail(
+                PaymentError(
+                    HttpStatus.UNAUTHORIZED.value().toString(),
+                    authException.message ?: "인증이 필요합니다."
+                )
+            )
+
+        val result = mapper.writeValueAsString(error)
+
+        response.status = HttpServletResponse.SC_UNAUTHORIZED
+        response.contentType = "application/json;charset=UTF-8"
+        response.writer.write(result)
+    }
 }

--- a/api/src/main/kotlin/com/inner/circle/api/security/MerchantApiKeyAuthenticationFilter.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/security/MerchantApiKeyAuthenticationFilter.kt
@@ -1,34 +1,46 @@
 package com.inner.circle.api.security
 
+import com.inner.circle.api.exception.CustomAuthenticationEntryPoint
 import com.inner.circle.core.security.MerchantApiKeyProvider
 import com.inner.circle.exception.UserAuthenticationException
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpHeaders
+import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
 
 class MerchantApiKeyAuthenticationFilter(
-    private val provider: MerchantApiKeyProvider
+    private val provider: MerchantApiKeyProvider,
+    private val authenticationEntryPoint: CustomAuthenticationEntryPoint
 ) : OncePerRequestFilter() {
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        val authHeader =
-            request.getHeader(HttpHeaders.AUTHORIZATION)
-                ?: throw UserAuthenticationException.UnauthorizedException(
-                    "Missing Authorization header"
-                )
+        try {
+            val authHeader =
+                request.getHeader(HttpHeaders.AUTHORIZATION)
+                    ?: throw UserAuthenticationException.UnauthorizedException(
+                        "Missing Authorization header"
+                    )
 
-        val apiKey = resolveApiKey(authHeader)
+            val apiKey = resolveApiKey(authHeader)
 
-        val authentication = provider.getAuthentication(apiKey)
-        SecurityContextHolder.getContext().authentication = authentication
+            val authentication = provider.getAuthentication(apiKey)
+            SecurityContextHolder.getContext().authentication = authentication
 
-        filterChain.doFilter(request, response)
+            filterChain.doFilter(request, response)
+        } catch (ex: Exception) {
+            SecurityContextHolder.clearContext()
+            authenticationEntryPoint.commence(
+                request,
+                response,
+                BadCredentialsException(ex.message)
+            )
+        }
     }
 
     private fun resolveApiKey(authHeader: String): String {

--- a/api/src/main/kotlin/com/inner/circle/api/security/SecurityConfig.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/security/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package com.inner.circle.api.security
 
+import com.inner.circle.api.exception.CustomAuthenticationEntryPoint
 import com.inner.circle.core.security.MerchantApiKeyProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -11,7 +12,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
-    private val merchantApiKeyProvider: MerchantApiKeyProvider
+    private val merchantApiKeyProvider: MerchantApiKeyProvider,
+    private val authenticationEntryPoint: CustomAuthenticationEntryPoint
 ) {
     @Bean
     fun apiSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
@@ -25,7 +27,10 @@ class SecurityConfig(
                     .anyRequest()
                     .hasAuthority("ROLE_MERCHANT")
             }.addFilterBefore(
-                MerchantApiKeyAuthenticationFilter(merchantApiKeyProvider),
+                MerchantApiKeyAuthenticationFilter(
+                    merchantApiKeyProvider,
+                    authenticationEntryPoint
+                ),
                 UsernamePasswordAuthenticationFilter::class.java
             ).formLogin { it.disable() }
         return http.build()


### PR DESCRIPTION
## 개요
- .exceptionHandling() 에 AccessDeniedHandler, AuthenticationEntryPoint를 등록하는 방법을 사용했지만 security filter에서 오류 발생시 이전과 동일하게 서버 오류 500이 반환되었습니다.
- HandlerExceptionResolver 방법도 사용해 봤지만 위와 동일하게 서버 오류 500이 반환됬습니다
- 더 좋은 방법이 있을 것 같은데 우선 FE에 동일한 에러 응답이 내려가도록 수정했습니다!

```json
{
  "ok": false,
  "error": {
    "code": "401",
    "message": "Missing Authorization header"
  }
}
```

> 티켓 번호 : #190 

## PR 유형
- [x] 버그 수정
