### PR TITLE
fix(155): 카드사 목서버 요청 오류 수정

### DIFF
--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -40,6 +40,6 @@ spring:
 
 card:
   url:
-    base-url: http://localhost:8082
+    base-url: https://mock.pay-200.com
     approve-end-point: /mock/card/approve
     validate-end-point: /mock/card/validate


### PR DESCRIPTION
## 개요
- 카드사 url 설정하여 요청 오류 없도록 수정했습니다.
  - https://mock.pay-200.com

> 티켓 번호 : # {}

## PR 유형
<!-- 해당 pr 의 유형을 선택해 주세요. -->
- [ ] 버그 수정
