### PR TITLE
fix(222): paymentToken 저장 - hashing 처리

### DIFF
--- a/api/src/test/resources/sql/schema.sql
+++ b/api/src/test/resources/sql/schema.sql
@@ -88,12 +88,10 @@ create table if not exists account
     updated_at timestamp(6) default CURRENT_TIMESTAMP not null
 );
 
-INSERT INTO account (id, email, password, status, created_at, updated_at) VALUES (293847562342874239, 'test@test.com', '$2a$10$S09UPOa5ZQh4n/Yb1PdRnuoJgWJ.f.Z20', 0, '2025-02-12 22:05:32.901464', '2025-02-12 22:05:32.901464');
+INSERT INTO account (id, email, password, status, created_at, updated_at) VALUES (293847562342874239, 'test@test.com', '$2a$10$8I6102l2DJvon6gkFJUHh.ZAeszd5swcabHdpr8iFsDXJ6WOZ51v2', 0, '2025-02-12 22:05:32.901464', '2025-02-12 22:05:32.901464');
 INSERT INTO merchant (id, email, password, token, name, created_at, updated_at) VALUES (435345345, 'pay200', 'pay200', 'pay200', 'pay200', '2025-02-11 20:25:42.000000', '2025-02-11 20:25:42.000000');
 INSERT INTO user_card (id, account_id, is_representative, card_number, expiration_period, cvc, created_at, updated_at) VALUES (7295051915259393268, 5, true, '4567-8923-6378-3982', '03/28', '654', '2025-02-11 21:20:14.188948', '2025-02-11 21:20:14.188948');
 INSERT INTO user_card (id, account_id, is_representative, card_number, expiration_period, cvc, created_at, updated_at) VALUES (7295051915258292529, 3, true, '9876-5432-1098-7654', '01/27', '789', '2025-02-11 21:20:14.188948', '2025-02-11 21:20:14.188948');
 INSERT INTO user_card (id, account_id, is_representative, card_number, expiration_period, cvc, created_at, updated_at) VALUES (7295051915259438759, 2, true, '5678-1234-5678-9012', '10/23', '456', '2025-02-11 21:20:14.188948', '2025-02-11 21:20:14.188948');
 INSERT INTO user_card (id, account_id, is_representative, card_number, expiration_period, cvc, created_at, updated_at) VALUES (7295051915262387503, 293847562342874239, true, '1234-5678-9012-3456', '12/25', '123', '2025-02-11 21:20:14.188948', '2025-02-11 21:20:14.188948');
 INSERT INTO user_card (id, account_id, is_representative, card_number, expiration_period, cvc, created_at, updated_at) VALUES (7295051915258934220, 1, true, '4321-8765-4321-8765', '03/24', '987', '2025-02-11 21:20:14.188948', '2025-02-11 21:20:14.188948');
-
-

--- a/core/src/main/kotlin/com/inner/circle/core/service/PaymentPaymentTokenHandleService.kt
+++ b/core/src/main/kotlin/com/inner/circle/core/service/PaymentPaymentTokenHandleService.kt
@@ -19,7 +19,7 @@ class PaymentPaymentTokenHandleService(
         val orderId = paymentData.orderId
         val validateToken =
             jwtHandler.validateToken(
-                paymentData.generatedToken,
+                token,
                 paymentData.signature
             )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,6 +82,8 @@ jwt = {module = "io.jsonwebtoken:jjwt", version = "0.12.6"}
 logbackDiscordAppender = { module = "com.github.napstr:logback-discord-appender", version = "1.0.0" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version = "2.9.0" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version = "3.14.9" }
+# guava
+guava = {module = "com.google.guava:guava", version = "33.4.0-jre"}
 
 [bundles]
 boms = ["kotlinxSerializationBom", "kotlinxCoroutinesBom", "kotestBom"]

--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation(libs.awsSecretsManagerConfig)
     implementation(libs.springBootDataRedis)
     implementation(libs.bundles.hypersistence)
+    implementation(libs.guava)
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
     implementation("org.springframework.boot:spring-boot-starter-security")

--- a/infra/src/main/kotlin/com/inner/circle/infra/adaptor/PaymentTokenAdaptor.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/adaptor/PaymentTokenAdaptor.kt
@@ -1,8 +1,10 @@
 package com.inner.circle.infra.adaptor
 
+import com.google.common.hash.Hashing
 import com.inner.circle.infra.adaptor.dto.PaymentTokenDto
 import com.inner.circle.infra.port.PaymentTokenHandlingPort
 import com.inner.circle.infra.repository.entity.PaymentTokenRepository
+import java.nio.charset.StandardCharsets
 import org.springframework.stereotype.Component
 
 @Component
@@ -10,7 +12,8 @@ class PaymentTokenAdaptor(
     private val paymentTokenRepository: PaymentTokenRepository
 ) : PaymentTokenHandlingPort {
     override fun getMerchantIdAndOrderIdFromPaymentToken(token: String): PaymentTokenDto {
-        val paymentDataFromToken = paymentTokenRepository.getPaymentDataFromToken(token)
+        val hashedToken = Hashing.murmur3_128().hashString(token, StandardCharsets.UTF_8).toString()
+        val paymentDataFromToken = paymentTokenRepository.getPaymentDataFromToken(hashedToken)
         return PaymentTokenDto(
             merchantId = paymentDataFromToken.merchantId,
             orderId = paymentDataFromToken.orderId,

--- a/infra/src/main/kotlin/com/inner/circle/infra/adaptor/dto/PaymentClaimDto.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/adaptor/dto/PaymentClaimDto.kt
@@ -1,10 +1,12 @@
 package com.inner.circle.infra.adaptor.dto
 
+import com.google.common.hash.Hashing
 import com.inner.circle.exception.PaymentClaimException
 import com.inner.circle.infra.repository.entity.PaymentRequestEntity
 import com.inner.circle.infra.repository.entity.PaymentStatusType
 import com.inner.circle.infra.repository.entity.PaymentType
 import java.math.BigDecimal
+import java.nio.charset.StandardCharsets
 import java.time.LocalDateTime
 
 class PaymentClaimDto(
@@ -60,7 +62,8 @@ class PaymentClaimDto(
             orderId: String?
         ) {
             if (orderName.isNullOrEmpty() ||
-                orderId.isNullOrEmpty()
+                orderId.isNullOrEmpty() ||
+                merchantId <= 0L
             ) {
                 throw PaymentClaimException.BadPaymentClaimRequestException()
             }
@@ -86,7 +89,13 @@ class PaymentClaimDto(
             cardNumber = cardNumber,
             paymentKey = paymentKey,
             amount = amount,
-            paymentToken = tokenData.generatedToken,
+            paymentToken =
+                Hashing
+                    .murmur3_128()
+                    .hashString(
+                        tokenData.generatedToken,
+                        StandardCharsets.UTF_8
+                    ).toString(),
             requestTime = requestTime
         )
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/adaptor/dto/PaymentTokenDto.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/adaptor/dto/PaymentTokenDto.kt
@@ -1,6 +1,8 @@
 package com.inner.circle.infra.adaptor.dto
 
+import com.google.common.hash.Hashing
 import com.inner.circle.infra.repository.entity.PaymentTokenEntity
+import java.nio.charset.StandardCharsets
 import java.time.LocalDateTime
 
 data class PaymentTokenDto(
@@ -14,7 +16,13 @@ data class PaymentTokenDto(
         PaymentTokenEntity(
             merchantId = merchantId,
             orderId = orderId,
-            generatedToken = generatedToken,
+            generatedToken =
+                Hashing
+                    .murmur3_128()
+                    .hashString(
+                        generatedToken,
+                        StandardCharsets.UTF_8
+                    ).toString(),
             signature = signature
         )
 }

--- a/infra/src/test/kotlin/com/inner/circle/infra/adaptor/PaymentTokenTest.kt
+++ b/infra/src/test/kotlin/com/inner/circle/infra/adaptor/PaymentTokenTest.kt
@@ -1,0 +1,34 @@
+package com.inner.circle.infra.adaptor
+
+import com.google.common.hash.Hashing
+import java.nio.charset.StandardCharsets
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class PaymentTokenTest {
+    private lateinit var initialHash: String
+    private val logger: Logger = LoggerFactory.getLogger(PaymentTokenTest::class.java)
+
+    @BeforeEach
+    fun setUp() {
+        val target =
+            "eyJhbGciOiJIUzM4NCJ9.eyJtZXJjaGFudE5hbWUiOiJwYXkyMDAiLCJvcmRlcklkIjoiMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxIiwib3JkZXJOYW1lIjoiMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxIiwiYW1vdW50IjoxMCwiaWF0IjoxNzM5ODA2MzQ2fQ.G-MJad-bAIY9t7CJIy2MK7-TEKRs6QCzkneuc-YV-QSbqEug_6dqSMJl2XPTuDlE"
+        initialHash = Hashing.murmur3_128().hashString(target, StandardCharsets.UTF_8).toString()
+    }
+
+    @RepeatedTest(100)
+    fun hashingTest() {
+        val target =
+            "eyJhbGciOiJIUzM4NCJ9.eyJtZXJjaGFudE5hbWUiOiJwYXkyMDAiLCJvcmRlcklkIjoiMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxIiwib3JkZXJOYW1lIjoiMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxIiwiYW1vdW50IjoxMCwiaWF0IjoxNzM5ODA2MzQ2fQ.G-MJad-bAIY9t7CJIy2MK7-TEKRs6QCzkneuc-YV-QSbqEug_6dqSMJl2XPTuDlE"
+        val hash = Hashing.murmur3_128().hashString(target, StandardCharsets.UTF_8).toString()
+
+        // 해시 값이 초기 해시 값과 일치하는지 확인
+        logger.info("hash: $hash")
+        assertEquals(initialHash, hash)
+        Assertions.assertThat(hash).hasSize(32)
+    }
+}


### PR DESCRIPTION
## 개요
- guava lib - Hashing 사용 (murmur3_128)
  - Hashing.murmur3_128().hashString(tokenData.generatedToken, StandardCharsets.UTF_8).toString()
- PaymentTokenTest.kt 를 통해 100번 수행 시 동일한 hash String 처리됨 확인
- PaymentTokenMemoryRepositoryTest.kt 가 정상 동작하도록 수정
- schema.sql password 수정

> 티켓 번호 : #222 

## PR 유형
<!-- 해당 pr 의 유형을 선택해 주세요. -->
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 기타 (설명을 남겨주세요.) -> guava library 추가
