### PR TITLE
274/sse connection in ttl - App 측 (결제 고객) sse 연결은 payment가 살아있는 동안에만 유효하다.

### DIFF
--- a/api/src/main/kotlin/com/inner/circle/api/application/PaymentStatusChangedMessageSender.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/application/PaymentStatusChangedMessageSender.kt
@@ -44,7 +44,7 @@ class PaymentStatusChangedMessageSender(
             )
         } catch (e: NoSuchElementException) {
             log.error("get sse session failed", e)
-            throw SseException.connectionNotFound(merchantId, orderId)
+            throw SseException.ConnectionNotFoundException(merchantId.toString(), orderId)
         }
     }
 
@@ -75,7 +75,7 @@ class PaymentStatusChangedMessageSender(
             )
         } catch (e: NoSuchElementException) {
             log.error("get sse session failed", e)
-            throw SseException.connectionNotFound(merchantId, orderId)
+            throw SseException.ConnectionNotFoundException(merchantId.toString(), orderId)
         }
     }
 }

--- a/api/src/main/kotlin/com/inner/circle/api/controller/merchant/MerchantSseApiController.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/controller/merchant/MerchantSseApiController.kt
@@ -32,8 +32,6 @@ class MerchantSseApiController(
     ): ResponseBodyEmitter {
         val merchantId = merchantUserDetails.getId().toString()
 
-        paymentTokenHandlingUseCase.checkPaymentStatus(merchantId, orderId)
-
         val sseConnection =
             com.inner.circle.core.sse.SseConnection.connect(
                 merchantId + "_" + orderId,

--- a/api/src/main/kotlin/com/inner/circle/api/controller/merchant/MerchantSseApiController.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/controller/merchant/MerchantSseApiController.kt
@@ -5,6 +5,7 @@ import com.inner.circle.api.config.SwaggerConfig
 import com.inner.circle.api.controller.PaymentForMerchantV1Api
 import com.inner.circle.core.security.MerchantUserDetails
 import com.inner.circle.core.sse.SseConnectionPool
+import com.inner.circle.core.usecase.PaymentTokenHandlingUseCase
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.slf4j.LoggerFactory
@@ -19,7 +20,8 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter
 @SecurityRequirement(name = SwaggerConfig.BASIC_AUTH)
 class MerchantSseApiController(
     private val sseConnectionPool: SseConnectionPool,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val paymentTokenHandlingUseCase: PaymentTokenHandlingUseCase
 ) {
     private val log = LoggerFactory.getLogger(MerchantSseApiController::class.java)
 
@@ -29,7 +31,8 @@ class MerchantSseApiController(
         @RequestParam orderId: String
     ): ResponseBodyEmitter {
         val merchantId = merchantUserDetails.getId().toString()
-        log.info("SSE merchant ({}) connected.", merchantId + "_" + orderId)
+
+        paymentTokenHandlingUseCase.checkPaymentStatus(merchantId, orderId)
 
         val sseConnection =
             com.inner.circle.core.sse.SseConnection.connect(
@@ -38,25 +41,9 @@ class MerchantSseApiController(
                 objectMapper
             )
 
+        log.info("SSE merchant ({}) connected.", merchantId + "_" + orderId)
         sseConnectionPool.addSession(sseConnection.uniqueKey, sseConnection)
 
         return sseConnection.sseEmitter
-    }
-
-    @Deprecated("test용으로 구성된 api이므로 제거 예정입니다.")
-    @GetMapping("/sse/pushEvent")
-    fun pushEvent(
-        @AuthenticationPrincipal merchantUserDetails: MerchantUserDetails,
-        @RequestParam orderId: String,
-        @RequestParam message: String
-    ) {
-        val connection =
-            sseConnectionPool.getSessions(
-                merchantUserDetails.getId().toString() + "_" + orderId
-            )
-
-        for (sseConnection in connection) {
-            sseConnection.sendMessage(message)
-        }
     }
 }

--- a/api/src/main/kotlin/com/inner/circle/api/controller/user/UserSseApiController.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/controller/user/UserSseApiController.kt
@@ -28,8 +28,8 @@ class UserSseApiController(
         @RequestParam merchantId: String,
         @RequestParam orderId: String
     ): ResponseBodyEmitter {
+        paymentTokenHandlingUseCase.checkPaymentStatus(merchantId, orderId)
         val uniqueKey = "${merchantId}_$orderId"
-        log.info("SSE user ({}) connected.", uniqueKey)
         val sseConnection =
             com.inner.circle.core.sse.SseConnection.connect(
                 uniqueKey,
@@ -37,6 +37,7 @@ class UserSseApiController(
                 objectMapper
             )
 
+        log.info("SSE user ({}) connected.", uniqueKey)
         sseConnectionPool.addSession(sseConnection.uniqueKey, sseConnection)
 
         return sseConnection.sseEmitter

--- a/core/src/main/kotlin/com/inner/circle/core/service/PaymentPaymentTokenHandleService.kt
+++ b/core/src/main/kotlin/com/inner/circle/core/service/PaymentPaymentTokenHandleService.kt
@@ -3,7 +3,6 @@ package com.inner.circle.core.service
 import com.inner.circle.core.service.dto.PaymentTokenHandleDto
 import com.inner.circle.core.usecase.PaymentTokenHandlingUseCase
 import com.inner.circle.exception.PaymentJwtException
-import com.inner.circle.exception.SseException
 import com.inner.circle.infra.port.PaymentTokenHandlingPort
 import org.springframework.stereotype.Service
 
@@ -40,10 +39,8 @@ class PaymentPaymentTokenHandleService(
     override fun checkPaymentStatus(
         merchantId: String,
         orderId: String
-    ) {
+    ): Boolean {
         val checkPaymentStatus = paymentTokenHandlingPort.checkPaymentStatus(merchantId, orderId)
-        if (checkPaymentStatus.isBlank()) {
-            throw SseException.EndOfPaymentProgressException()
-        }
+        return checkPaymentStatus.isNotBlank()
     }
 }

--- a/core/src/main/kotlin/com/inner/circle/core/service/PaymentPaymentTokenHandleService.kt
+++ b/core/src/main/kotlin/com/inner/circle/core/service/PaymentPaymentTokenHandleService.kt
@@ -3,6 +3,7 @@ package com.inner.circle.core.service
 import com.inner.circle.core.service.dto.PaymentTokenHandleDto
 import com.inner.circle.core.usecase.PaymentTokenHandlingUseCase
 import com.inner.circle.exception.PaymentJwtException
+import com.inner.circle.exception.SseException
 import com.inner.circle.infra.port.PaymentTokenHandlingPort
 import org.springframework.stereotype.Service
 
@@ -34,5 +35,15 @@ class PaymentPaymentTokenHandleService(
             orderId = orderId,
             generatedToken = token
         )
+    }
+
+    override fun checkPaymentStatus(
+        merchantId: String,
+        orderId: String
+    ) {
+        val checkPaymentStatus = paymentTokenHandlingPort.checkPaymentStatus(merchantId, orderId)
+        if (checkPaymentStatus.isBlank()) {
+            throw SseException.EndOfPaymentProgressException()
+        }
     }
 }

--- a/core/src/main/kotlin/com/inner/circle/core/usecase/PaymentTokenHandlingUseCase.kt
+++ b/core/src/main/kotlin/com/inner/circle/core/usecase/PaymentTokenHandlingUseCase.kt
@@ -4,4 +4,9 @@ import com.inner.circle.core.service.dto.PaymentTokenHandleDto
 
 interface PaymentTokenHandlingUseCase {
     fun findPaymentToken(token: String): PaymentTokenHandleDto
+
+    fun checkPaymentStatus(
+        merchantId: String,
+        orderId: String
+    )
 }

--- a/core/src/main/kotlin/com/inner/circle/core/usecase/PaymentTokenHandlingUseCase.kt
+++ b/core/src/main/kotlin/com/inner/circle/core/usecase/PaymentTokenHandlingUseCase.kt
@@ -8,5 +8,5 @@ interface PaymentTokenHandlingUseCase {
     fun checkPaymentStatus(
         merchantId: String,
         orderId: String
-    )
+    ): Boolean
 }

--- a/exception/src/main/kotlin/com/inner/circle/exception/SseException.kt
+++ b/exception/src/main/kotlin/com/inner/circle/exception/SseException.kt
@@ -12,4 +12,9 @@ sealed class SseException(
             "SSE connection not found for merchantId: $merchantId, orderId: $orderId",
         override val cause: Throwable? = null
     ) : SseException(HttpStatus.NOT_FOUND, message, cause)
+
+    data class EndOfPaymentProgressException(
+        override val message: String = "Payment process has ended.",
+        override val cause: Throwable? = null
+    ) : SseException(HttpStatus.BAD_REQUEST, message, cause)
 }

--- a/exception/src/main/kotlin/com/inner/circle/exception/SseException.kt
+++ b/exception/src/main/kotlin/com/inner/circle/exception/SseException.kt
@@ -1,18 +1,15 @@
 package com.inner.circle.exception
 
-class SseException(
+sealed class SseException(
     status: HttpStatus,
     override val message: String,
     override val cause: Throwable? = null
 ) : AppException(status, message, cause) {
-    companion object {
-        fun connectionNotFound(
-            merchantId: Long,
-            orderId: String
-        ): SseException =
-            SseException(
-                HttpStatus.NOT_FOUND,
-                "SSE connection not found for merchantId: $merchantId, orderId: $orderId"
-            )
-    }
+    data class ConnectionNotFoundException(
+        val merchantId: String,
+        val orderId: String,
+        override val message: String =
+            "SSE connection not found for merchantId: $merchantId, orderId: $orderId",
+        override val cause: Throwable? = null
+    ) : SseException(HttpStatus.NOT_FOUND, message, cause)
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/adaptor/PaymentClaimAdaptor.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/adaptor/PaymentClaimAdaptor.kt
@@ -51,6 +51,11 @@ class PaymentClaimAdaptor(
         val savedPaymentRequest = paymentClaimRepository.save(paymentRequest)
         // token entity 저장
         paymentTokenRepository.savePaymentToken(tokenEntity, expiredAt)
+        paymentTokenRepository.savePaymentInProgress(
+            tokenEntity.merchantId.toString(),
+            tokenEntity.orderId,
+            expiredAt
+        )
 
         return PaymentClaimDto.fromEntity(savedPaymentRequest)
     }

--- a/infra/src/main/kotlin/com/inner/circle/infra/adaptor/PaymentTokenAdaptor.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/adaptor/PaymentTokenAdaptor.kt
@@ -26,4 +26,9 @@ class PaymentTokenAdaptor(
     override fun deletePaymentToken(token: String) {
         paymentTokenRepository.removePaymentDataByToken(token)
     }
+
+    override fun checkPaymentStatus(
+        merchantId: String,
+        orderId: String
+    ): String = paymentTokenRepository.checkPaymentInProgress(merchantId, orderId).orEmpty()
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/port/PaymentTokenHandlingPort.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/port/PaymentTokenHandlingPort.kt
@@ -6,4 +6,9 @@ interface PaymentTokenHandlingPort {
     fun getMerchantIdAndOrderIdFromPaymentToken(token: String): PaymentTokenDto
 
     fun deletePaymentToken(token: String)
+
+    fun checkPaymentStatus(
+        merchantId: String,
+        orderId: String
+    ): String
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/repository/entity/PaymentTokenRepository.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/repository/entity/PaymentTokenRepository.kt
@@ -12,7 +12,14 @@ interface PaymentTokenRepository {
 
     fun removePaymentDataByToken(token: String)
 
-    fun checkPaymentInProgress(merchantId: String, orderId: String): String?
+    fun checkPaymentInProgress(
+        merchantId: String,
+        orderId: String
+    ): String?
 
-    fun savePaymentInProgress(merchantId: String, orderId: String, expiresAt: LocalDateTime): String
+    fun savePaymentInProgress(
+        merchantId: String,
+        orderId: String,
+        expiresAt: LocalDateTime
+    )
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/repository/entity/PaymentTokenRepository.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/repository/entity/PaymentTokenRepository.kt
@@ -11,4 +11,8 @@ interface PaymentTokenRepository {
     ): PaymentTokenEntity
 
     fun removePaymentDataByToken(token: String)
+
+    fun checkPaymentInProgress(merchantId: String, orderId: String): String?
+
+    fun savePaymentInProgress(merchantId: String, orderId: String, expiresAt: LocalDateTime): String
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/repository/memorydatabase/PaymentTokenMemoryRepository.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/repository/memorydatabase/PaymentTokenMemoryRepository.kt
@@ -1,7 +1,6 @@
 package com.inner.circle.infra.repository.memorydatabase
 
 import com.inner.circle.exception.PaymentJwtException
-import com.inner.circle.exception.SseException
 import com.inner.circle.infra.repository.entity.PaymentTokenEntity
 import com.inner.circle.infra.repository.entity.PaymentTokenRepository
 import java.time.Duration
@@ -72,7 +71,6 @@ class PaymentTokenMemoryRepository(
         orderId: String
     ): String? {
         val key = "$merchantId:$orderId"
-        return redisTemplate.opsForValue()[key]
-            ?: throw SseException.ConnectionNotFoundException(merchantId, orderId)
+        return redisTemplate.opsForValue()[key].orEmpty()
     }
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/repository/memorydatabase/PaymentTokenMemoryRepository.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/repository/memorydatabase/PaymentTokenMemoryRepository.kt
@@ -1,6 +1,7 @@
 package com.inner.circle.infra.repository.memorydatabase
 
 import com.inner.circle.exception.PaymentJwtException
+import com.inner.circle.exception.SseException
 import com.inner.circle.infra.repository.entity.PaymentTokenEntity
 import com.inner.circle.infra.repository.entity.PaymentTokenRepository
 import java.time.Duration
@@ -56,11 +57,22 @@ class PaymentTokenMemoryRepository(
         }
     }
 
-    override fun savePaymentInProgress(merchantId: String, orderId: String, expiresAt: LocalDateTime): String {
-        TODO("Not yet implemented")
+    override fun savePaymentInProgress(
+        merchantId: String,
+        orderId: String,
+        expiresAt: LocalDateTime
+    ) {
+        val key = "$merchantId:$orderId"
+        val ttl = Duration.between(LocalDateTime.now(), expiresAt)
+        redisTemplate.opsForValue().set(key, "paymentInProcess", ttl)
     }
 
-    override fun checkPaymentInProgress(merchantId: String, orderId: String): String? {
-        TODO("Not yet implemented")
+    override fun checkPaymentInProgress(
+        merchantId: String,
+        orderId: String
+    ): String? {
+        val key = "$merchantId:$orderId"
+        return redisTemplate.opsForValue()[key]
+            ?: throw SseException.ConnectionNotFoundException(merchantId, orderId)
     }
 }

--- a/infra/src/main/kotlin/com/inner/circle/infra/repository/memorydatabase/PaymentTokenMemoryRepository.kt
+++ b/infra/src/main/kotlin/com/inner/circle/infra/repository/memorydatabase/PaymentTokenMemoryRepository.kt
@@ -55,4 +55,12 @@ class PaymentTokenMemoryRepository(
             logger.error("Failed to remove token: $token", ex)
         }
     }
+
+    override fun savePaymentInProgress(merchantId: String, orderId: String, expiresAt: LocalDateTime): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun checkPaymentInProgress(merchantId: String, orderId: String): String? {
+        TODO("Not yet implemented")
+    }
 }


### PR DESCRIPTION
## 개요
- 차후 보완할 예정이나
- 우선은 merchantId, orderId로 TTL 을 걸어 저장해두고
- 해당 값을 조회하지 못하면 App 측 sse는 연결되지 않도록 구성했습니다.

> 티켓 번호 : # {}

## PR 유형
<!-- 해당 pr 의 유형을 선택해 주세요. -->
- [ ] 새로운 기능 추가
