### PR TITLE
fix(306): 결제 요청 생성 시 orderName이 잘못 설정된 구간을 바로잡습니다.

### DIFF
--- a/api/src/main/kotlin/com/inner/circle/api/controller/merchant/MerchantPaymentController.kt
+++ b/api/src/main/kotlin/com/inner/circle/api/controller/merchant/MerchantPaymentController.kt
@@ -50,7 +50,7 @@ class MerchantPaymentController(
             PaymentClaimUseCase.ClaimRequest(
                 amount = request.amount,
                 orderId = request.orderId,
-                orderName = request.orderId
+                orderName = request.orderName
             )
 
         val response = claimUseCase.createPayment(claimRequest, merchantId, merchantName)


### PR DESCRIPTION
## 개요
결제 요청 시 orderName (주문서 이름)이 orderId로 설정된 구간이 확인되어 이를 바로잡습니다.

> 티켓 번호 : #306

## PR 유형
<!-- 해당 pr 의 유형을 선택해 주세요. -->
- [x] 버그 수정
