### PR TITLE
fix(payment, backoffice): 시간 검증 로직 수정

### DIFF
--- a/core-backoffice/src/main/kotlin/com/inner/circle/corebackoffice/service/TransactionService.kt
+++ b/core-backoffice/src/main/kotlin/com/inner/circle/corebackoffice/service/TransactionService.kt
@@ -12,7 +12,8 @@ import com.inner.circle.exception.PaymentException
 import com.inner.circle.infrabackoffice.port.GetPaymentPort
 import com.inner.circle.infrabackoffice.port.GetTransactionPort
 import com.inner.circle.infrabackoffice.port.SaveTransactionPort
-import java.time.format.DateTimeFormatter
+import java.time.ZoneId
+import java.util.Locale
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toJavaLocalDate
 import org.springframework.context.i18n.LocaleContextHolder
@@ -167,12 +168,8 @@ internal class TransactionService(
         startDate?.let { start ->
             endDate?.let { end ->
                 val locale = LocaleContextHolder.getLocale()
-                val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd", locale)
-                val currentDate =
-                    java.time.LocalDate
-                        .now()
-                        .format(formatter)
-                        .let { java.time.LocalDate.parse(it, formatter) }
+                val zoneId = getZoneIdForLocale(locale)
+                val currentDate = java.time.LocalDate.now(zoneId)
                 require(start <= end) {
                     throw BackofficeException.InvalidParameterRequestException(
                         parameterName = null,
@@ -184,10 +181,20 @@ internal class TransactionService(
                 ) {
                     throw BackofficeException.InvalidParameterRequestException(
                         parameterName = null,
-                        message = "endDate는 현재 날짜보다 미래일 수 없습니다."
+                        message = "endDate($end)는 현재($currentDate) 보다 미래일 수 없습니다."
                     )
                 }
             }
         }
     }
+
+    fun getZoneIdForLocale(locale: Locale): ZoneId =
+        when (locale.country) {
+            "KR" -> ZoneId.of("Asia/Seoul")
+            "US" -> ZoneId.of("America/New_York")
+            "JP" -> ZoneId.of("Asia/Tokyo")
+            "CN" -> ZoneId.of("Asia/Shanghai")
+            "DE" -> ZoneId.of("Europe/Berlin")
+            else -> ZoneId.of("UTC")
+        }
 }


### PR DESCRIPTION
## 개요
현재 날짜 이후의 결제 내역을 조회하지 못하도록 하는 검증 로직에서 문제 발생

Local 환경 개발 시 Application의 TimeZone은 `Asia/Seoul`
그러나, AWS EC2에 배포된 Application은 `UTC` 혹은 `America/New_York` TimeZone을 가진다.

그래서 로컬 테스트 시 문제없었지만, 배포 후 이슈가 생겼다.
이는 앞으로 모든 LocalDate.now()와 같이 현재 시각을 기준으로 하는 로직에 영향을 끼친다.

결론, Local에서도 Application은 UTC TimeZone을 기본으로 설정하고,
로직을 TimeZone에 맞도록 설정하는 로직이 필요할 것 같다.
우선 검증 로직에만 적용

혹은 반대로 한국 시각으로 기준을 잡는 방법도?

> 티켓 번호 : #fix/datetime-validate.1

## PR 유형
- [X] 버그 수정